### PR TITLE
Add support for removing SVG root by remove method

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -101,8 +101,14 @@ SVG.Element = SVG.invent({
     }
     // Remove element
   , remove: function() {
-      if (this.parent)
-        this.parent.removeElement(this)
+      if (this.parent) {
+        if(this.parent.removeElement)
+            this.parent.removeElement(this)
+        else if(this.parent.removeChild)
+            this.parent.removeChild(this.node)
+        
+        delete this.parent
+      }
       
       return this
     }


### PR DESCRIPTION
If <svg> element is attached to HTML element (which is, I suppose, common use case), you can remove it by calling `remove` method of object returned by SVG() function. The same like you remove SVG elements from SVG document.