### PR TITLE
Add support for event namespaces

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -50,7 +50,7 @@ SVG.on = function(node, event, listener) {
   SVG.listeners[node][event][listener] = l
 
   // add listener
-  node.addEventListener(event, l, false)
+  node.addEventListener(event.split('.')[0], l, false)
 }
 
 // Add event unbinder in the SVG namespace
@@ -59,7 +59,7 @@ SVG.off = function(node, event, listener) {
     // remove listener reference
     if (SVG.listeners[node] && SVG.listeners[node][event]) {
       // remove listener
-      node.removeEventListener(event, SVG.listeners[node][event][listener], false)
+      node.removeEventListener(event.split('.')[0], SVG.listeners[node][event][listener], false)
 
       delete SVG.listeners[node][event][listener]
     }


### PR DESCRIPTION
This will add support for namespaces on events known from jQuery (see http://css-tricks.com/namespaced-events-jquery/). My problem was that I was using the draggable plugin and I has problems registering a mousedown event because draggable also registered a mousedown event on the same element and unregistered it when I called fixed() on that element. My own event handler was removed, too. With namespaces, I can register and unregister "my own" events.

Example:
```javascript
rect.on('mousedown.myPlugin', function(event) {
     // do the work
});
```
```javascript
rect.off('mousedown.myPlugin');
```