### PR TITLE
Added missing `.bbox()` calls to merge example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1450,8 +1450,8 @@ As opposed to the native `getBBox()` method any translations used with the `tran
 The `SVG.BBox` has one other nifty little feature, enter the `merge()` method. With `merge()` two `SVG.BBox` instances can be merged into one new instance, basically being the bounding box of the two original bounding boxes:
 
 ```javascript
-var box1 = draw.rect(100,100).move(50,50)
-var box2 = draw.rect(100,100).move(200,200)
+var box1 = draw.rect(100,100).move(50,50).bbox()
+var box2 = draw.rect(100,100).move(200,200).bbox()
 var box3 = box1.merge(box2)
 ```
 


### PR DESCRIPTION
Hey there. I may be misunderstanding, so feel free to dismiss this, but the `merge` method example for `BBox` wasn't working. I looked at the source for a few minutes, and realized that the first two lines in the example were missing a call to `bbox`, since `merge` belongs to `BBox` instances, not `Rect` instances.

Thanks for making such a great lib. Really enjoying it so far :sparkles: