### PR TITLE
Fixed npm warning about "repositories" property

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,9 @@
     , "url":      "http://www.opensource.org/licenses/mit-license.php"
     }
   ]
-, "repositories": [
-    {
-      "type":     "git"
-    , "url":      "https://github.com/wout/svg.js.git"
-    }
-  ]
+, "repository": {
+    "type":     "git"
+  , "url":      "https://github.com/wout/svg.js.git"
+  }
 , "github":       "https://github.com/wout/svg.js"
 }


### PR DESCRIPTION
After adding *svg.js* as a dependency

```
$ npm install svg.js --save                                                                                                                        
svg.js@1.0.1 node_modules/svg.js
```

when I update deps I get a warning

```
$ npm install
npm WARN package.json svg.js@1.0.1 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
svg.js@1.0.1 node_modules/svg.js
```