### PR TITLE
Update boxes.js

### DIFF
--- a/src/boxes.js
+++ b/src/boxes.js
@@ -10,17 +10,11 @@ SVG.BBox = SVG.invent({
         // find native bbox
         box = element.node.getBBox()
       } catch(e) {
-        if(element instanceof SVG.Shape){
-          var clone = element.clone().addTo(SVG.parser.draw)
-          box = clone.bbox()
-          clone.remove()
-        }else{
-          box = {
-            x:      element.node.clientLeft
-          , y:      element.node.clientTop
-          , width:  element.node.clientWidth
-          , height: element.node.clientHeight
-          }
+        box = {
+          x:      element.node.clientLeft
+        , y:      element.node.clientTop
+        , width:  element.node.clientWidth
+        , height: element.node.clientHeight
         }
       }
       


### PR DESCRIPTION
In Firefox I had this problem that these commands goes straight into infinity loop. Because the cloned object could also not calculate bbox so it made a new cloned one. This new clone could also not calculate the bbox and so on.

var clone = element.clone().addTo(SVG.parser.draw)
          box = clone.bbox()
          clone.remove()