### PR TITLE
Fix regex for isNumber

### DIFF
--- a/src/regex.js
+++ b/src/regex.js
@@ -34,7 +34,7 @@ SVG.regex = {
 , isBlank:          /^(\s+)?$/
   
   // Test for numeric string
-, isNumber:         /^-?[\d\.]+$/
+, isNumber:         /^[+-]?(\d+(\.\d*)?|\.\d+)(e[+-]?\d+)?$/i
 
   // Test for percent value
 , isPercent:        /^-?[\d\.]+%$/


### PR DESCRIPTION
Description of necessary functionality for a regex that matches Javascript numbers found in Eloquent Javascript, (Ch 9, last exercise). See: http://eloquentjavascript.net/09_regexp.html#h_izldJoT3uv

Probably solves issue #438.