### PR TITLE
Uncaught TypeError: Cannot read property 'node' of null

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -171,7 +171,7 @@ SVG.Element = SVG.invent({
       if(!type) return parent
 
       // loop trough ancestors if type is given
-      while(parent.node instanceof SVGElement){
+      while(parent && parent.node instanceof SVGElement){
         if(typeof type === 'string' ? parent.matches(type) : parent instanceof type) return parent
         parent = SVG.adopt(parent.node.parentNode)
       }


### PR DESCRIPTION
I've encountered situation where SVG.adopt (line 176) returns null, which leads to `Uncaught TypeError: Cannot read property 'node' of null`. Checking whether parent exists fixes it.