### PR TITLE
fix Inside function bbox to tbox

### DIFF
--- a/src/element.js
+++ b/src/element.js
@@ -97,7 +97,7 @@ SVG.Element = SVG.invent({
     }
     // Checks whether the given point inside the bounding box of the element
   , inside: function(x, y) {
-      var box = this.bbox()
+      var box = this.tbox()
 
       return x > box.x
           && y > box.y


### PR DESCRIPTION
It seems inside function should use tbox instead of bbox because after move() bbox still returns {x:0, y:0} but object actually change his position.

I'm can't understand actual usability of current version of bbox, it seems that prev version of bbox that currently has name tbox is what I'm needed