### PR TITLE
Fix groups animation

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -263,7 +263,12 @@ SVG.Transformation = SVG.invent({
     }
 
   , undo: function(o){
+      for(var i = 0, len = this.arguments.length; i < len; ++i){
+        o[this.arguments[i]] = typeof this[this.arguments[i]] == 'undefined' ? 0 : o[this.arguments[i]]
+      }
+      
       this._undo = new SVG[capitalize(this.method)](o, true).at(1)
+      
       return this
     }
 


### PR DESCRIPTION
When you use 'move' animation of the group element, and use transformation for only one coordinate (x or y) then it's resets other coordinate to 0. 
For example if your group is on coordinate 100, 100 and you call animate y(500), it goes to 0, 500.

This is caused because undo is made for both coordinates. 