### PR TITLE
Changed document.contains to document.body.contains

### DIFF
--- a/src/boxes.js
+++ b/src/boxes.js
@@ -9,7 +9,7 @@ SVG.BBox = SVG.invent({
       try {
 
         // the element is NOT in the dom, throw error
-        if(!document.contains(element.node)) throw new Exception('Element not in the dom')
+        if(!document.body.contains(element.node)) throw new Exception('Element not in the dom')
 
         // find native bbox
         box = element.node.getBBox()

--- a/src/boxes.js
+++ b/src/boxes.js
@@ -9,7 +9,7 @@ SVG.BBox = SVG.invent({
       try {
 
         // the element is NOT in the dom, throw error
-        if(!document.body.contains(element.node)) throw new Exception('Element not in the dom')
+        if(!document.documentElement.contains(element.node)) throw new Exception('Element not in the dom')
 
         // find native bbox
         box = element.node.getBBox()


### PR DESCRIPTION
 The document object in IE does not have the contains function  as a method.  This can cause a stack overflow as you can get stuck in an endless try catch loop.   document.body.contains will work in IE, Firefox, and Chrome and will resolve this issue.